### PR TITLE
Fix oauth2 for net-smtp 0.4.0

### DIFF
--- a/lib/mail_xoauth2/smtp_xoauth2_authenticator.rb
+++ b/lib/mail_xoauth2/smtp_xoauth2_authenticator.rb
@@ -1,40 +1,61 @@
 # frozen_string_literal: true
 
-require 'net/smtp'
-require 'base64'
+if Gem::Version.new(Net::SMTP::VERSION) >= Gem::Version.new('0.4.0')
+  # create xoauth2 class, until this https://github.com/ruby/net-smtp/pull/80/files lands in a new net-smtp version
+  class Net::SMTP
+    class AuthXoauth2 < Net::SMTP::Authenticator
+      auth_type :xoauth2
 
-module MailXoauth2
-  module SmtpXoauth2Authenticator
-    def send_xoauth2(auth_token)
-      critical do
-        get_response("AUTH XOAUTH2 #{auth_token}")
+      def auth(user, secret)
+        token = xoauth2_string(user, secret)
+
+        finish("AUTH XOAUTH2 #{base64_encode(token)}")
+      end
+
+      private
+
+      def xoauth2_string(user, secret)
+        "user=#{user}\1auth=Bearer #{secret}\1\1"
       end
     end
-    private :send_xoauth2
-
-    def get_final_status
-      critical do
-        get_response('')
-      end
-    end
-    private :get_final_status
-
-    def auth_xoauth2(user, oauth2_token)
-      check_auth_args user, oauth2_token
-
-      auth_string = build_oauth2_string(user, oauth2_token)
-      res = send_xoauth2(base64_encode(auth_string))
-
-      # See note about SMTP protocol exchange in https://developers.google.com/gmail/xoauth2_protocol
-      res = get_final_status if res.continue?
-
-      check_auth_response res
-      res
-    end
-
-    include Oauth2String
   end
-end
+else
+  require 'net/smtp'
+  require 'base64'
 
-# Not pretty, right ?
-Net::SMTP.__send__('include', MailXoauth2::SmtpXoauth2Authenticator)
+  module MailXoauth2
+    module SmtpXoauth2Authenticator
+      def send_xoauth2(auth_token)
+        critical do
+          get_response("AUTH XOAUTH2 #{auth_token}")
+        end
+      end
+      private :send_xoauth2
+
+      def get_final_status
+        critical do
+          get_response('')
+        end
+      end
+      private :get_final_status
+
+      def auth_xoauth2(user, oauth2_token)
+        check_auth_args user, oauth2_token
+
+        auth_string = build_oauth2_string(user, oauth2_token)
+        res = send_xoauth2(base64_encode(auth_string))
+
+        # See note about SMTP protocol exchange in https://developers.google.com/gmail/xoauth2_protocol
+        res = get_final_status if res.continue?
+
+        check_auth_response res
+        res
+      end
+
+      include Oauth2String
+    end
+  end
+
+  # Not pretty, right ?
+  Net::SMTP.__send__('include', MailXoauth2::SmtpXoauth2Authenticator)
+end


### PR DESCRIPTION
In net-smtp 0.4.0, auth_* methods are moved out from the Net::SMTP class, see this [PR](https://github.com/ruby/net-smtp/pull/53). Instead you should create a new class that inherits from `Net::SMTP::Authenticator`. There is a [PR](https://github.com/ruby/net-smtp/pull/80) already merged that adds a xoauth2 class to net-smtp. Until it gets released with a new version of net-smtp, lets add it to mail_xoauth2?